### PR TITLE
Fixing missing icon for onlyclick-50plus

### DIFF
--- a/sass/lib/_coverwallet-font.scss
+++ b/sass/lib/_coverwallet-font.scss
@@ -678,7 +678,7 @@
     content: "\e9a1";
 }
 .cwicon-onlyclick-50plus:before {
-    content: "\e92e";
+    content: "\e99f";
 }
 .cwicon-onlyclick-no:before {
     content: "\e9aa";

--- a/styleguide/public/coverwallet-styleguide.css
+++ b/styleguide/public/coverwallet-styleguide.css
@@ -6425,7 +6425,7 @@ html {
   content: "\e9a1"; }
 
 .cwicon-onlyclick-50plus:before, .styleguide-icon-onlyclick-50plus:before {
-  content: "\e92e"; }
+  content: "\e99f"; }
 
 .cwicon-onlyclick-no:before, .styleguide-icon-onlyclick-no:before {
   content: "\e9aa"; }


### PR DESCRIPTION
Recovering icon missing:

**Before**

![screen shot 2017-10-17 at 13 27 14](https://user-images.githubusercontent.com/1155574/31662527-ff6b415a-b33e-11e7-9985-2185f3401d0e.png)

**After**

![screen shot 2017-10-17 at 13 26 52](https://user-images.githubusercontent.com/1155574/31662541-07c34870-b33f-11e7-94ec-dba8dc374514.png)
